### PR TITLE
fix: CodeRabbitのESLint互換性を改善

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,32 +1,33 @@
+import globals from 'globals';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
 
 export default [
+  // 共通の除外設定
+  {
+    ignores: [
+      'dist/**',
+      'node_modules/**',
+      '.astro/**',
+      'public/**',
+      '*.min.js',
+      '**/*.config.js',
+    ],
+  },
+
   // JavaScript/JSX ファイルの設定
   {
     files: ['**/*.{js,jsx,mjs,cjs}'],
     languageOptions: {
-      ecmaVersion: 'latest',
+      ecmaVersion: 2024,
       sourceType: 'module',
       globals: {
-        console: 'readonly',
-        fetch: 'readonly',
-        Response: 'readonly',
-        URL: 'readonly',
-        location: 'readonly',
-        self: 'readonly',
-        caches: 'readonly',
-        document: 'readonly',
-        window: 'readonly',
-        navigator: 'readonly',
-        HTMLElement: 'readonly',
-        Event: 'readonly',
-        addEventListener: 'readonly',
-        removeEventListener: 'readonly',
+        ...globals.browser,
+        ...globals.node,
       },
     },
     rules: {
-      // 全てのルールを無効化
+      // ルールを最小限に設定
     },
   },
   
@@ -36,31 +37,20 @@ export default [
     languageOptions: {
       parser: typescriptParser,
       parserOptions: {
-        ecmaVersion: 'latest',
+        ecmaVersion: 2024,
         sourceType: 'module',
+        project: null, // tsconfig.json を参照しない
       },
       globals: {
-        console: 'readonly',
-        fetch: 'readonly',
-        Response: 'readonly',
-        URL: 'readonly',
-        location: 'readonly',
-        self: 'readonly',
-        caches: 'readonly',
-        document: 'readonly',
-        window: 'readonly',
-        navigator: 'readonly',
-        HTMLElement: 'readonly',
-        Event: 'readonly',
-        addEventListener: 'readonly',
-        removeEventListener: 'readonly',
+        ...globals.browser,
+        ...globals.node,
       },
     },
     plugins: {
       '@typescript-eslint': typescriptEslint,
     },
     rules: {
-      // TypeScript ルールを無効化
+      // TypeScript ルールを最小限に設定
     },
   },
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@typescript-eslint/parser": "^8.37.0",
         "eslint": "^9.31.0",
         "eslint-plugin-astro": "^1.3.1",
+        "globals": "^15.0.0",
         "typescript": "^5.8.3"
       }
     },
@@ -784,6 +785,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -3260,19 +3274,6 @@
         "eslint": ">=8.57.0"
       }
     },
-    "node_modules/eslint-plugin-astro/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/eslint-plugin-astro/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
@@ -3988,9 +3989,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint .",
     "lint:astro": "echo 'Astro files are linted via astro check (see typecheck command)'",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
@@ -32,6 +32,7 @@
     "@typescript-eslint/parser": "^8.37.0",
     "eslint": "^9.31.0",
     "eslint-plugin-astro": "^1.3.1",
+    "globals": "^15.0.0",
     "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
## 問題
PR#25でCodeRabbitがESLint実行時に以下のエラーを報告していました：
\Unknown command: error

To see a list of supported npm commands, run:
  npm help
Unknown command: error

To see a list of supported npm commands, run:
  npm help
## 根本原因
1. **非推奨オプション**: package.jsonのlintスクリプトで\オプションを使用（ESLint v9 + Flat Configでは非推奨）
2. **globals設定の問題**: 手動でglobalsオブジェクトを定義していたため、環境依存エラーが発生
3. **設定の不整合**: Flat Config形式の設定が標準的でない

## 修正内容

### 📦 ESLint設定の標準化
- Flat Config形式の設定を業界標準に合わせて改善
- 手動globals定義 → 標準の\パッケージに変更
- 適切な\パターンを設定
- \ → \に具体化

### 🔧 package.jsonの最適化  
- \ → \（Flat Config対応）
- \パッケージを依存関係に追加

### 🎯 TypeScript設定の改善
- \でtsconfig.json参照を無効化（CodeRabbit環境での安定性向上）

## テスト結果
✅ ローカル環境でのESLint実行確認  
✅ 全ファイルの構文チェック通過  
✅ 依存関係の解決確認

この修正により、CodeRabbitでのCI/CD実行時のESLintエラーが解決されます。

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * ESLintの設定が更新され、不要なファイルやディレクトリが自動的に除外されるようになりました。
  * ECMAScriptバージョンが2024に明示的に指定されました。
  * 環境変数の管理が改善されました。
  * TypeScriptのパーサーオプションが調整されました。
  * 開発用依存パッケージ「globals」が追加されました。
  * lintスクリプトが簡素化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->