### PR TITLE
記事カードのキーボードナビゲーション・フォーカス表示改善

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -123,6 +123,20 @@
   - 記事の閲覧数表示
   - トレンド分析機能
 
+## コード整理・リファクタリング
+- [ ] **コンポーネント構成の整理**
+  - `src/components/`直下の散在しているコンポーネントを機能別にグループ化
+  - **移動予定の構成**:
+    - `common/` - 汎用コンポーネント（Breadcrumb, SearchBox, SocialLinks, SocialShare, StructuredData, ThemeToggle）
+    - `navigation/` - ナビゲーション関連（Pagination, MobileTableOfContents, TableOfContents）
+    - `pwa/` - PWA関連（InstallPrompt）
+  - **作業内容**:
+    - フォルダ作成と各ファイルの移動
+    - 全インポートパスの更新（各使用箇所で相対パス変更）
+    - 動作テスト（ビルド・表示確認）
+  - **メリット**: 整理整頓、可読性向上、保守性向上
+  - **優先度**: 低（現状でも十分機能している）
+
 ## デプロイ・運用
 - [ ] **Cloudflare Pages公開**
   - ドメイン設定

--- a/src/components/blog/ArticleCard.astro
+++ b/src/components/blog/ArticleCard.astro
@@ -35,6 +35,7 @@ const displayTags = compact ? tags.slice(0, 2) : tags;
       href={articleUrl} 
       class="block rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-all duration-300 ease-out hover:shadow-md dark:hover:shadow-gray-900/20 hover:translate-y-[-1px]"
       aria-label={`記事「${title}」を読む`}
+      tabindex="0"
     >
       <div class="flex gap-4">
         <!-- 記事画像 -->
@@ -71,10 +72,9 @@ const displayTags = compact ? tags.slice(0, 2) : tags;
             {displayTags.map((tag) => (
               <Tag
                 tag={tag}
-                href={`/search?q=${encodeURIComponent(tag)}`}
                 variant="default"
                 size="sm"
-                interactive={true}
+                interactive={false}
               />
             ))}
           </div>
@@ -89,6 +89,7 @@ const displayTags = compact ? tags.slice(0, 2) : tags;
       href={articleUrl} 
       class="block relative overflow-hidden"
       aria-label={`記事「${title}」を読む`}
+      tabindex="0"
     >
       <!-- 記事画像 -->
       <div class="aspect-[4/3] overflow-hidden relative">
@@ -137,10 +138,9 @@ const displayTags = compact ? tags.slice(0, 2) : tags;
           {displayTags.map((tag, index) => (
             <Tag
               tag={tag}
-              href={`/tags/${tag.toLowerCase().replace(/\s+/g, '-')}/`}
               variant="default"
               size="sm"
-              interactive={true}
+              interactive={false}
               class="transform hover:scale-105 hover:shadow-sm"
             />
           ))}
@@ -166,10 +166,27 @@ const displayTags = compact ? tags.slice(0, 2) : tags;
     overflow: hidden;
   }
   
-  /* アクセシビリティ: フォーカス表示の改善 */
-  a:focus {
+  /* キーボードナビゲーション時のみフォーカス表示 */
+  article:has(a:focus-visible) {
     outline: 2px solid #3b82f6;
     outline-offset: 2px;
+    border-radius: 8px;
+  }
+  
+  /* リンクのデフォルトフォーカス枠を非表示 */
+  a:focus {
+    outline: none;
+  }
+  
+  /* 内部要素のフォーカスを防ぐ */
+  a * {
+    pointer-events: none;
+    user-select: none;
+  }
+  
+  /* aタグ自体はクリック可能にする */
+  a {
+    pointer-events: auto;
   }
   
   /* スムーズなアニメーション */


### PR DESCRIPTION
## Summary
- Tabキー1回で次の記事カードに移動できるよう改善
- キーボード操作時のみフォーカス枠を表示、マウスクリック時は非表示
- 記事カード内のタグリンクを無効化してナビゲーション効率化

## 主な変更内容
- **キーボードナビゲーション改善**: 記事カード内の複数要素（タグ等）のフォーカスを無効化し、Tabキー1回で次のカードに移動
- **フォーカス表示の最適化**: `:focus-visible`を使用してキーボード操作時のみ青い枠線を表示
- **アクセシビリティ向上**: 記事カード全体にフォーカス枠を適用し、視認性向上
- **タグリンク無効化**: 記事カード内のタグは表示専用とし、リンク機能を削除

## Test plan
- [ ] ブログページでTabキーナビゲーションが1回で次の記事に移動することを確認
- [ ] マウスクリック時に青い枠線が表示されないことを確認  
- [ ] キーボード操作時にフォーカス枠が適切に表示されることを確認
- [ ] 記事カードのクリック動作が正常に機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * TODOリストに「コード整理・リファクタリング」セクションを追加しました。

* **スタイル**
  * 記事カードのキーボードフォーカス時のアウトライン表示を改善し、アクセシビリティを向上させました。

* **バグ修正**
  * タグ要素のリンク機能を無効化し、不要なインタラクションを防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->