### PR TITLE
記事カードの説明文を非表示に変更

### DIFF
--- a/src/components/blog/ArticleCard.astro
+++ b/src/components/blog/ArticleCard.astro
@@ -62,10 +62,10 @@ const displayTags = compact ? tags.slice(0, 2) : tags;
             {title}
           </h2>
           
-          <!-- 説明 -->
-          <p class="text-xs text-gray-600 dark:text-gray-400 mb-2 line-clamp-2 group-hover:text-gray-700 dark:group-hover:text-gray-200 transition-colors duration-200">
+          <!-- 説明 (非表示) -->
+          <!-- <p class="text-xs text-gray-600 dark:text-gray-400 mb-2 line-clamp-2 group-hover:text-gray-700 dark:group-hover:text-gray-200 transition-colors duration-200">
             {description}
-          </p>
+          </p> -->
           
           <!-- タグ -->
           <div class="flex flex-wrap gap-1">
@@ -128,10 +128,10 @@ const displayTags = compact ? tags.slice(0, 2) : tags;
           {title}
         </h2>
         
-        <!-- 説明 -->
-        <p class="text-sm text-gray-600 dark:text-gray-300 mb-4 line-clamp-3 group-hover:text-gray-700 dark:group-hover:text-gray-200 transition-colors duration-200">
+        <!-- 説明 (非表示) -->
+        <!-- <p class="text-sm text-gray-600 dark:text-gray-300 mb-4 line-clamp-3 group-hover:text-gray-700 dark:group-hover:text-gray-200 transition-colors duration-200">
           {description}
-        </p>
+        </p> -->
         
         <!-- タグ -->
         <div class="flex flex-wrap gap-2 transform group-hover:translate-y-[-2px] transition-transform duration-200">


### PR DESCRIPTION
## Summary
- 記事カード（ホーム・ブログ一覧ページ）の説明文（description）を非表示に変更
- 今後使用予定がないためコメントアウトで無効化

## 変更内容
- **ホームページの記事カード**: コンパクト版のdescription表示を無効化
- **ブログ一覧ページの記事カード**: グリッド版のdescription表示を無効化
- コメントアウトで実装し、必要時に簡単に復活可能

## メリット
- レイアウトがよりクリーンに
- タイトルとタグに焦点を当てた表示
- 必要に応じて簡単に復活可能（コメント解除のみ）

## Test plan
- [ ] ホームページで説明文が表示されないことを確認
- [ ] ブログ一覧ページで説明文が表示されないことを確認
- [ ] レイアウトが適切に調整されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)