### PR TITLE
BIZ UDPGothicフォントへの統一

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&display=swap');
 @import './components.css';
 @import './remark-link-card.css';
 
@@ -12,22 +12,29 @@
   }
   
   html {
-    font-family: 'Inter', system-ui, sans-serif;
+    font-family: 'BIZ UDPGothic', 'Hiragino Sans', 'Yu Gothic', system-ui, sans-serif;
     scroll-behavior: smooth;
     @apply bg-gray-100 dark:bg-gray-900;
   }
   
   body {
     @apply bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200;
+    font-family: 'BIZ UDPGothic', 'Hiragino Sans', 'Yu Gothic', system-ui, sans-serif;
     font-feature-settings: 'rlig' 1, 'calt' 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    line-height: 1.7;
   }
 }
 
 @layer components {
   .prose {
     @apply max-w-none text-gray-700 dark:text-gray-300;
+    font-family: 'BIZ UDPGothic', 'Hiragino Sans', 'Yu Gothic', system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    letter-spacing: 0.05em;
   }
   
   .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -5,7 +5,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: ['BIZ UDPGothic', 'Hiragino Sans', 'Yu Gothic', 'system-ui', 'sans-serif'],
       }
     },
   },


### PR DESCRIPTION
## 概要
UIと記事本文のフォントをBIZ UDPGothicに統一し、読みやすさとデザインの一貫性を向上させました。

## 主な変更点
• Google FontsのインポートをBIZ UDPGothicに変更
• html, body, .proseの全てでBIZ UDPGothicフォントを使用
• tailwind.config.mjsのfont-sansもBIZ UDPGothicに統一
• 文字間隔を0.05em、行間を1.7に設定して読みやすさを向上

## 改善効果
• フォントの歪みやデコボコ感を解消
• UIと記事本文の統一されたフォント表示
• より読みやすい文字レンダリング

## テスト結果
• ビルド: ✅ 正常完了
• 動作確認: ✅ フォント表示問題なし

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * アプリ全体のデフォルトフォントが「Inter」から「BIZ UDPGothic」「Hiragino Sans」「Yu Gothic」など日本語フォント優先のスタックに変更されました。
  * テキストの可読性向上のため、行間や文字間、フォントウェイト、フォントスムージングなどのスタイルが調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->