### PR TITLE
chore: remove unused imports (astro.config.mjs, search.astro)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,11 +2,8 @@ import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
 import remarkLinkCard from 'remark-link-card';
 import rehypeRaw from 'rehype-raw';
-import rehypeExternalLinks from 'rehype-external-links';
 
 export default defineConfig({
   site: 'https://astro-blog.pages.dev', // Cloudflare Pages URL

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -2,7 +2,6 @@
 import Layout from '../layouts/Layout.astro';
 import Header from '../components/layout/Header.astro';
 import Footer from '../components/layout/Footer.astro';
-import ArticleCard from '../components/blog/ArticleCard.astro';
 import Breadcrumb from '../components/Breadcrumb.astro';
 import { getCollection } from 'astro:content';
 import { cleanContentForSearch } from '../lib/utils/blog';


### PR DESCRIPTION
目的: 未使用インポートの整理による設定の明確化とビルドの安定性向上
- 変更点:
    - astro.config.mjs: createRequire/require と未使用の rehype-external-links のインポート削除
    - src/pages/search.astro: 未使用の ArticleCard インポート削除
- 影響範囲: インポートのみ（機能変更なし）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 検索ページの内部実装を簡素化し、特定コンポーネントへの依存を解消。表示構造・検索の挙動は従来どおりです。
  - 設定から不要な動的読み込みと未使用の外部リンク処理を削除。機能面の影響はありません。
- Chores
  - レガシーな設定・未使用コードのクリーンアップを実施し、保守性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->