### PR TITLE
feat: enable rehype-external-links for external link safety

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
 import remarkLinkCard from 'remark-link-card';
 import rehypeRaw from 'rehype-raw';
+import rehypeExternalLinks from 'rehype-external-links';
 
 export default defineConfig({
   site: 'https://astro-blog.pages.dev', // Cloudflare Pages URL
@@ -20,7 +21,16 @@ export default defineConfig({
         shortenUrl: true
       }]
     ],
-    rehypePlugins: [rehypeRaw],
+    rehypePlugins: [
+      rehypeRaw,
+      [
+        rehypeExternalLinks,
+        {
+          target: '_blank',
+          rel: ['noopener', 'noreferrer'],
+        },
+      ],
+    ],
     shikiConfig: {
       theme: 'github-dark',
       wrap: true


### PR DESCRIPTION
Purpose

- 外部リンクの安全性と挙動を統一するため、Markdown/MDX 内の外部リンクへ自動的に target="_blank" と rel="noopener
noreferrer" を付与

Changes

- astro.config.mjs:
    - rehype-external-links を導入
    - markdown.rehypePlugins に [rehypeExternalLinks, { target: '_blank', rel: ['noopener','noreferrer'] }] を追加
    - 既存の remark-link-card/rehype-raw 設定は維持

Behavior

- 対象: Markdown/MDX で記述された外部リンク（リンクカード含む）
- 効能: 新規タブで開きつつ、reverse tabnabbing 対策を自動化
- 非対象: Astro コンポーネント内の手書きリンク（Header/Footer 等）は現状のまま
- 内部リンク: /path や相対リンクは変更なし（同一ドメインの絶対URLは今は外部扱いになる可能性あり）